### PR TITLE
Fix error interpolation on malformed requests

### DIFF
--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -66,7 +66,7 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
         :'User-Agent' => "logstash-output-slack",
         :content_type => @content_type) { |response, request, result, &block|
           if response.code != 200
-            @logger.warn("Got a #{response.code} result: " + result)
+            @logger.warn("Got a #{response.code} response: #{response}")
           end
         }
     rescue Exception => e


### PR DESCRIPTION
Fixes traces like this, if you, say, omit the '#' in your channel name:

root@f986c8becbda:~# /opt/logstash/bin/logstash -e '
input { stdin {} }
output { slack { username => "loggy" icon_emoji => ":evergreen_tree:"
format => "%{message}" channel => "signups" url =>
"your-slack-URL"
} }'
slack plugin is using the 'milestone' method to declare the version of
the plugin this method is deprecated in favor of declaring the version
inside the gemspec. {:level=>:warn}
Logstash startup completed
Testing testing 1 2 3
Unhandled exception {:exception=>#<TypeError: can't convert
Net::HTTPInternalServerError into String>,
:stacktrace=>["org/jruby/RubyString.java:1157:in `+'",
"/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-slack-0.1.0/lib/logstash/outputs/slack.rb:69:in
`receive'", "org/jruby/RubyProc.java:271:in `call'",
"/opt/logstash/vendor/bundle/jruby/1.9/gems/rest-client-1.8.0/lib/restclient/request.rb:493:in
`process_result'",
"/opt/logstash/vendor/bundle/jruby/1.9/gems/rest-client-1.8.0/lib/restclient/request.rb:421:in
`transmit'", "/opt/logstash/vendor/jruby/lib/ruby/1.9/net/http.rb:746:in
`start'",
"/opt/logstash/vendor/bundle/jruby/1.9/gems/rest-client-1.8.0/lib/restclient/request.rb:413:in
`transmit'",
"/opt/logstash/vendor/bundle/jruby/1.9/gems/rest-client-1.8.0/lib/restclient/request.rb:176:in
`execute'",
"/opt/logstash/vendor/bundle/jruby/1.9/gems/rest-client-1.8.0/lib/restclient/request.rb:41:in
`execute'",
"/opt/logstash/vendor/bundle/jruby/1.9/gems/rest-client-1.8.0/lib/restclient.rb:69:in
`post'",
"/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-output-slack-0.1.0/lib/logstash/outputs/slack.rb:64:in
`receive'",
"/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.0-java/lib/logstash/outputs/base.rb:88:in
`handle'", "(eval):22:in `output_func'",
"/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.0-java/lib/logstash/pipeline.rb:244:in
`outputworker'",
"/opt/logstash/vendor/bundle/jruby/1.9/gems/logstash-core-1.5.0-java/lib/logstash/pipeline.rb:166:in
`start_outputs'"], :level=>:warn}
