### PR TITLE
Add support for configured and per-event attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,19 @@ output {
     ...
     slack {
         url => <YOUR SLACK WEBHOOK URL HERE>
-        channel => [channel-name - this is optional]
-        username => [slack username - this is optional]
+        channel => [channel-name - optional]
+        username => [slack username - optional]
         icon_emoji => [emoji, something like ":simple_smile:" - optional]
         icon_url => [icon url, would be overriden by icon_emoji - optional]
         format => [default is "%{message}", but used to format the text - optional]
+        attachments => [an array of attachment maps as specified by the slack API - optional; if there is an "attachments" field in the event map and it is valid, it will override what is configured here, even if it's empty]
     }
 }
 ```
 
-Not supported yet: attachments
-
 ### Changelog:
+- [v0.1.2](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.2):
+    - Added support for attachments
 - [v0.1.1](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.1):
     - Added variable expansion to usernames and channel names ([#6](https://github.com/cyli/logstash-output-slack/pull/6))
     - Fixed bug when reporting malformed requests ([#3](https://github.com/cyli/logstash-output-slack/pull/3))

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-slack'
-  s.version         = '0.1.1'
+  s.version         = '0.1.2'
   s.licenses        = ['MIT','Apache License (2.0)']
   s.summary         = "Write events to Slack"
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-codec-plain"
   s.add_runtime_dependency "rest-client"
   s.add_development_dependency "logstash-devutils"
+  s.add_development_dependency "logstash-filter-json"
   s.add_development_dependency "logstash-input-generator"
   s.add_development_dependency "webmock"
 

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -119,16 +119,12 @@ describe LogStash::Outputs::Slack do
     end
 
     it "uses the default attachments if none are in the event" do
-      stub_request(:post, "requestb.in").
-        to_return(:body => "", :status => 200,
-                  :headers => { 'Content-Length' => 0 })
-
       expected_json = {
         :text => "This message should show in slack",
         :attachments => [{:image_url => "http://example.com/image.png"}]
       }
 
-      LogStash::Pipeline.new(<<-CONFIG
+      logstash_config = <<-CONFIG
           input {
             generator {
               message => "This message should show in slack"
@@ -144,28 +140,16 @@ describe LogStash::Outputs::Slack do
             }
           }
       CONFIG
-      ).run
 
-      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
-        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
-             :headers => {
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Accept'=> 'application/json',
-                'User-Agent' => 'logstash-output-slack'
-                })).
-        to have_been_made.once
+      test_one_event(logstash_config, expected_json)
     end
 
     it "ignores empty default attachments" do
-      stub_request(:post, "requestb.in").
-        to_return(:body => "", :status => 200,
-                  :headers => { 'Content-Length' => 0 })
-
       expected_json = {
         :text => "This message should show in slack"
       }
 
-      LogStash::Pipeline.new(<<-CONFIG
+      logstash_config = <<-CONFIG
           input {
             generator {
               message => "This message should show in slack"
@@ -179,32 +163,18 @@ describe LogStash::Outputs::Slack do
             }
           }
       CONFIG
-      ).run
 
-      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
-        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
-             :headers => {
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Accept'=> 'application/json',
-                'User-Agent' => 'logstash-output-slack'
-                })).
-        to have_been_made.once
+      test_one_event(logstash_config, expected_json)
     end
 
     it "uses event attachments over default attachments" do
-      stub_request(:post, "requestb.in").
-        to_return(:body => "", :status => 200,
-                  :headers => { 'Content-Length' => 0 })
-
-      attachments =
-
       expected_json = {
         :text => "This message should show in slack",
         :attachments => [{:thumb_url => "http://other.com/thumb.png"}]
       }
 
-      # add_field only takes string values
-      LogStash::Pipeline.new(<<-CONFIG
+      # add_field only takes string values, so we'll have to mutate to JSON
+      logstash_config = <<-CONFIG
           input {
             generator {
               message => "This message should show in slack"
@@ -229,31 +199,17 @@ describe LogStash::Outputs::Slack do
             }
           }
       CONFIG
-      ).run
 
-      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
-        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
-             :headers => {
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Accept'=> 'application/json',
-                'User-Agent' => 'logstash-output-slack'
-                })).
-        to have_been_made.once
+      test_one_event(logstash_config, expected_json)
     end
 
     it "erases default attachments if event attachments empty" do
-      stub_request(:post, "requestb.in").
-        to_return(:body => "", :status => 200,
-                  :headers => { 'Content-Length' => 0 })
-
-      attachments =
-
       expected_json = {
         :text => "This message should show in slack"
       }
 
-      # add_field only takes string values
-      LogStash::Pipeline.new(<<-CONFIG
+      # add_field only takes string values, so we'll have to mutate to JSON
+      logstash_config = <<-CONFIG
           input {
             generator {
               message => "This message should show in slack"
@@ -276,32 +232,17 @@ describe LogStash::Outputs::Slack do
             }
           }
       CONFIG
-      ).run
 
-      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
-        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
-             :headers => {
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Accept'=> 'application/json',
-                'User-Agent' => 'logstash-output-slack'
-                })).
-        to have_been_made.once
+      test_one_event(logstash_config, expected_json)
     end
 
     it "ignores event attachment if not array" do
-      stub_request(:post, "requestb.in").
-        to_return(:body => "", :status => 200,
-                  :headers => { 'Content-Length' => 0 })
-
-      attachments =
-
       expected_json = {
         :text => "This message should show in slack",
         :attachments => [{:image_url => "http://example.com/image.png"}]
       }
 
-      # add_field only takes string values
-      LogStash::Pipeline.new(<<-CONFIG
+      logstash_config = <<-CONFIG
           input {
             generator {
               message => "This message should show in slack"
@@ -318,16 +259,8 @@ describe LogStash::Outputs::Slack do
             }
           }
       CONFIG
-      ).run
 
-      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
-        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
-             :headers => {
-                'Content-Type' => 'application/x-www-form-urlencoded',
-                'Accept'=> 'application/json',
-                'User-Agent' => 'logstash-output-slack'
-                })).
-        to have_been_made.once
+      test_one_event(logstash_config, expected_json)
     end
   end
 end

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -117,5 +117,217 @@ describe LogStash::Outputs::Slack do
 
       test_one_event(logstash_config, expected_json)
     end
+
+    it "uses the default attachments if none are in the event" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      expected_json = {
+        :text => "This message should show in slack",
+        :attachments => [{:image_url => "http://example.com/image.png"}]
+      }
+
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => [
+                {image_url => "http://example.com/image.png"}
+              ]
+            }
+          }
+      CONFIG
+      ).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
+
+    it "ignores empty default attachments" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      expected_json = {
+        :text => "This message should show in slack"
+      }
+
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => []
+            }
+          }
+      CONFIG
+      ).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
+
+    it "uses event attachments over default attachments" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      attachments =
+
+      expected_json = {
+        :text => "This message should show in slack",
+        :attachments => [{:thumb_url => "http://other.com/thumb.png"}]
+      }
+
+      # add_field only takes string values
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+              add_field => {
+                attachments => '[{"thumb_url": "http://other.com/thumb.png"}]'
+              }
+            }
+          }
+          filter {
+            json {
+              source => "attachments"
+              target => "attachments"
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => [
+                {image_url => "http://example.com/image.png"}
+              ]
+            }
+          }
+      CONFIG
+      ).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
+
+    it "erases default attachments if event attachments empty" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      attachments =
+
+      expected_json = {
+        :text => "This message should show in slack"
+      }
+
+      # add_field only takes string values
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+              add_field => {attachments => '[]'}
+            }
+          }
+          filter {
+            json {
+              source => "attachments"
+              target => "attachments"
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => [
+                {image_url => "http://example.com/image.png"}
+              ]
+            }
+          }
+      CONFIG
+      ).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
+
+    it "ignores event attachment if not array" do
+      stub_request(:post, "requestb.in").
+        to_return(:body => "", :status => 200,
+                  :headers => { 'Content-Length' => 0 })
+
+      attachments =
+
+      expected_json = {
+        :text => "This message should show in slack",
+        :attachments => [{:image_url => "http://example.com/image.png"}]
+      }
+
+      # add_field only takes string values
+      LogStash::Pipeline.new(<<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+              add_field => {attachments => "baddata"}
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => [
+                {image_url => "http://example.com/image.png"}
+              ]
+            }
+          }
+      CONFIG
+      ).run
+
+      expect(a_request(:post, "http://requestb.in/r9lkbzr9").
+        with(:body => "payload=#{CGI.escape(JSON.dump(expected_json))}",
+             :headers => {
+                'Content-Type' => 'application/x-www-form-urlencoded',
+                'Accept'=> 'application/json',
+                'User-Agent' => 'logstash-output-slack'
+                })).
+        to have_been_made.once
+    end
   end
 end

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -144,6 +144,34 @@ describe LogStash::Outputs::Slack do
       test_one_event(logstash_config, expected_json)
     end
 
+    it "supports multiple default attachments" do
+      expected_json = {
+        :text => "This message should show in slack",
+        :attachments => [{:image_url => "http://example.com/image1.png"},
+                         {:image_url => "http://example.com/image2.png"}]
+      }
+
+      logstash_config = <<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              attachments => [
+                {image_url => "http://example.com/image1.png"},
+                {image_url => "http://example.com/image2.png"}
+              ]
+            }
+          }
+      CONFIG
+
+      test_one_event(logstash_config, expected_json)
+    end
+
     it "ignores empty default attachments" do
       expected_json = {
         :text => "This message should show in slack"
@@ -194,7 +222,8 @@ describe LogStash::Outputs::Slack do
             slack {
               url => "http://requestb.in/r9lkbzr9"
               attachments => [
-                {image_url => "http://example.com/image.png"}
+                {image_url => "http://example.com/image1.png"},
+                {image_url => "http://example.com/image2.png"}
               ]
             }
           }
@@ -227,7 +256,8 @@ describe LogStash::Outputs::Slack do
             slack {
               url => "http://requestb.in/r9lkbzr9"
               attachments => [
-                {image_url => "http://example.com/image.png"}
+                {image_url => "http://example.com/image1.png"},
+                {image_url => "http://example.com/image2.png"}
               ]
             }
           }


### PR DESCRIPTION
This fixes #7.

As mentioned in the PR:
1.  If there is an event "attachments" field, it takes precedence as long as it is a valid array.  (It is ignored if it's a string, for instance).
2.  If there is an empty (`[]`) event "attachments" field, no attachments will be sent to slack for that event no matter what the default configuration is.
3.  The default attachments configuration is used for every event unless overridden by a specific event.
