### PR TITLE
Fix core dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ rvm:
   - jruby-head
 
 jdk:
-  - openjdk6
   - openjdk7
   - oraclejdk7
   - oraclejdk8
@@ -17,6 +16,3 @@ notifications:
 
 matrix:
   fast_finish: true
-  exclude:
-    - rvm: jruby-head
-      jdk: openjdk6

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ output {
 ```
 
 ### Changelog:
+- [v0.1.4](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.4):
+    - Drops support for JDK6 ([#15](https://github.com/cyli/logstash-output-slack/pull/15))
+    - Fix gemspec requirements to support newer versions of logstash core ([#14](https://github.com/cyli/logstash-output-slack/pull/14))
+- [v0.1.3](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.3):
+    - No change - bug in releasing
 - [v0.1.2](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.2):
     - Added support for attachments
 - [v0.1.1](https://github.com/cyli/logstash-output-slack/releases/tag/v0.1.1):

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   # logstash-core > 2.0.0.snapshot3 requires jrjackson ~> 0.3.5, which requires
   # JDK7.
-  core_upper_bound = "~> 2.0.0.snapshot3"
+  core_upper_bound = "< 3.0.0"
   if RUBY_PLATFORM == 'java'
     s.platform        = RUBY_PLATFORM
     if java.lang.System.get_property('java.version') < "1.7"   # JDK6

--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -20,17 +20,8 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
 
-  # logstash-core > 2.0.0.snapshot3 requires jrjackson ~> 0.3.5, which requires
-  # JDK7.
-  core_upper_bound = "< 3.0.0"
-  if RUBY_PLATFORM == 'java'
-    s.platform        = RUBY_PLATFORM
-    if java.lang.System.get_property('java.version') < "1.7"   # JDK6
-      core_upper_bound = "<= 2.0.0.snapshot3"
-    end
-  end
-
-  s.add_runtime_dependency "logstash-core", core_upper_bound, ">= 1.4.0"
+  s.platform = "java"
+  s.add_runtime_dependency "logstash-core", "< 3.0.0", ">= 1.4.0"
   s.add_runtime_dependency "logstash-codec-plain", "~> 2.0.0", ">= 1.0.0"
   s.add_runtime_dependency "rest-client", '~> 1.8', ">= 1.8.0"
   s.add_development_dependency "logstash-devutils", "~> 0.0.16"


### PR DESCRIPTION
Drop support for JDK6, since logstash-core seems to be doing so.
