### PR TITLE
Fixes gemspec version specifiers 

### DIFF
--- a/logstash-output-slack.gemspec
+++ b/logstash-output-slack.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |s|
 
   s.platform = "java"
   s.add_runtime_dependency "logstash-core", "< 3.0.0", ">= 1.4.0"
-  s.add_runtime_dependency "logstash-codec-plain", "~> 2.0.0", ">= 1.0.0"
-  s.add_runtime_dependency "rest-client", '~> 1.8', ">= 1.8.0"
+  s.add_runtime_dependency "logstash-codec-plain", "< 2.1", ">= 1.0.0"
+  s.add_runtime_dependency "rest-client", "< 2.0", ">= 1.8.0"
   s.add_development_dependency "logstash-devutils", "~> 0.0.16"
-  s.add_development_dependency "logstash-filter-json", "~> 2.0.1", ">= 1.0.1"
-  s.add_development_dependency "logstash-input-generator", "~> 2.0.1", ">= 1.0.0"
-  s.add_development_dependency "webmock", "~> 1.22", ">= 1.21.0"
+  s.add_development_dependency "logstash-filter-json", "< 2.1", ">= 1.0.1"
+  s.add_development_dependency "logstash-input-generator", "< 2.1", ">= 1.0.0"
+  s.add_development_dependency "webmock", "< 2.0", ">= 1.21.0"
 end


### PR DESCRIPTION
I believe the dependencies that used the `~>` version specifier were incorrect or at least redundant.

For example:

```
 s.add_runtime_dependency "logstash-codec-plain", "~> 2.0.0", ">= 1.0.0"        
```

Says we want a version that matches the `>= 2.0.0, < 2.1` (from `~> 2.0.0)` _and_ `>= 1.0.0`.  The effect is that the `>= 1.0.0` is effectively trampled because there is also a `> 2.0.0`.  I believe your desire was to still allow versions from the 1.0 series, is that right?  If so, I have changed each one to use the ceiling version that would have been chosen from the `~>` operator but left the low end how it currently was.
