### PR TITLE
Add support for Options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ output {
         icon_url => [icon url, would be overriden by icon_emoji - optional]
         format => [default is "%{message}", but used to format the text - optional]
         attachments => [an array of attachment maps as specified by the slack API - optional; if there is an "attachments" field in the event map and it is valid, it will override what is configured here, even if it's empty]
+        options => [an *hash* of other misc options, currently supports two boolean values: auto_expand_links and auto_expand_media]
     }
 }
 ```

--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -27,6 +27,9 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
   # Attachments array as described https://api.slack.com/docs/attachments
   config :attachments, :validate => :array
 
+  # Other options, allows several options in one place
+  config :options, :validate => :hash
+
   public
   def register
     require 'rest-client'
@@ -70,6 +73,19 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
         payload_json['attachments'] = rubified['attachments']
       else
         payload_json.delete('attachments')
+      end
+    end
+    
+    if @options and not @options.empty?
+      @options.each do |key, value|
+        case key
+        when 'auto_expand_links'
+          # Only allow true/false values, otherwise defaults to false
+          payload_json['unfurl_links'] = ([true, false].include? value) ? value : false
+        when 'auto_expand_media'
+          # Only allow true/false values, otherwise defaults to false
+          payload_json['unfurl_media'] = ([true, false].include? value) ? value : false
+        end
       end
     end
 

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -292,5 +292,87 @@ describe LogStash::Outputs::Slack do
 
       test_one_event(logstash_config, expected_json)
     end
+    
+    it  "supports disabling link expansion option" do
+      expected_json = {
+        :text => "This message should show in slack",
+        :unfurl_links => true
+      }
+      
+      logstash_config = <<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              options => {
+                'auto_expand_links' => true
+              }
+            }
+          }
+      CONFIG
+
+      test_one_event(logstash_config, expected_json)
+    end
+
+    it  "supports disabling media expansion option" do
+      expected_json = {
+        :text => "This message should show in slack",
+        :unfurl_media => false
+      }
+      
+      logstash_config = <<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              options => {
+                'auto_expand_media' => false
+              }
+            }
+          }
+      CONFIG
+
+      test_one_event(logstash_config, expected_json)
+    end
+
+    it  "uses automatic fallback for disabling expansion option" do
+       #  for any non-boolean value in the options.auto_expand_(media|links) should fallbacks to false
+      expected_json = {
+        :text => "This message should show in slack",
+        :unfurl_links => false
+        :unfurl_media => false
+      }
+      
+      logstash_config = <<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              options => {
+                'auto_expand_media' => "non boolean value"
+                'auto_expand_links' => "just another invalid value"
+              }
+            }
+          }
+      CONFIG
+
+      test_one_event(logstash_config, expected_json)
+    end
+
   end
 end

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -349,7 +349,7 @@ describe LogStash::Outputs::Slack do
        #  for any non-boolean value in the options.auto_expand_(media|links) should fallbacks to false
       expected_json = {
         :text => "This message should show in slack",
-        :unfurl_links => false
+        :unfurl_links => false,
         :unfurl_media => false
       }
       


### PR DESCRIPTION
I added support for a generic "options" key.
Might not be the best solution, but my goal was to have some "container" for extra options?

Currently i only added the support of two, but thinking about it it might have been better to just have a "generic" way to add extra options.

@cyli let me know what you think.
