### PR TITLE
Add support for generic extra options. (Alternative)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ output {
         icon_url => [icon url, would be overriden by icon_emoji - optional]
         format => [default is "%{message}", but used to format the text - optional]
         attachments => [an array of attachment maps as specified by the slack API - optional; if there is an "attachments" field in the event map and it is valid, it will override what is configured here, even if it's empty]
+        options => [an *hash* of other misc options that are added automatically to the request]
     }
 }
 ```

--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -27,6 +27,9 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
   # Attachments array as described https://api.slack.com/docs/attachments
   config :attachments, :validate => :array
 
+  # Allow any other option that will be attached to the request
+  config :options, :validate => :hash
+
   public
   def register
     require 'rest-client'

--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -73,6 +73,12 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
       end
     end
 
+    if @options and not @options.empty?
+      @options.each do |key, value|
+        payload_json[key] = value
+      end
+    end
+
     begin
       RestClient.post(
         @url,

--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -75,7 +75,7 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
 
     if @options and not @options.empty?
       @options.each do |key, value|
-        payload_json[key] = value
+        payload_json["#{key}"] = value
       end
     end
 

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -339,7 +339,7 @@ describe LogStash::Outputs::Slack do
             slack {
               url => "http://requestb.in/r9lkbzr9"
               options => {
-                'unfurl_links' => false,
+                'unfurl_links' => false
                 'unfurl_media' => true
               }
             }

--- a/spec/outputs/slack_spec.rb
+++ b/spec/outputs/slack_spec.rb
@@ -292,5 +292,62 @@ describe LogStash::Outputs::Slack do
 
       test_one_event(logstash_config, expected_json)
     end
+    
+    it  "includes an option to the request" do
+       #  for any non-boolean value in the options.auto_expand_(media|links) should fallbacks to false
+      expected_json = {
+        :text => "This message should show in slack",
+        :unfurl_links => false
+      }
+      
+      logstash_config = <<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              options => {
+                'unfurl_links' => false
+              }
+            }
+          }
+      CONFIG
+
+      test_one_event(logstash_config, expected_json)
+    end
+    
+    it  "includes multiple options to the request" do
+       #  for any non-boolean value in the options.auto_expand_(media|links) should fallbacks to false
+      expected_json = {
+        :text => "This message should show in slack",
+        :unfurl_links => false,
+        :unfurl_media => true
+      }
+      
+      logstash_config = <<-CONFIG
+          input {
+            generator {
+              message => "This message should show in slack"
+              count => 1
+            }
+          }
+          output {
+            slack {
+              url => "http://requestb.in/r9lkbzr9"
+              options => {
+                'unfurl_links' => false,
+                'unfurl_media' => true
+              }
+            }
+          }
+      CONFIG
+
+      test_one_event(logstash_config, expected_json)
+    end
+    
   end
 end


### PR DESCRIPTION
Include a `options` config that will allow any parameter to be added to the request,
this allows supporting any further development of the Slack API without the need to
update this plugin every time they add a new parameter.

This is alternative to the pull request #20 and uses a more "generic" approach, but has less control on the output.
