### PR TITLE
icon_emoji variable substitution

### DIFF
--- a/lib/logstash/outputs/slack.rb
+++ b/lib/logstash/outputs/slack.rb
@@ -52,7 +52,7 @@ class LogStash::Outputs::Slack < LogStash::Outputs::Base
     end
 
     if not @icon_emoji.nil?
-      payload_json['icon_emoji'] = @icon_emoji
+      payload_json['icon_emoji'] = event.sprintf(@icon_emoji)
     end
 
     if not @icon_url.nil?


### PR DESCRIPTION
Variable substitution for 'icon_emoji' like in 'channel' and 'username'
